### PR TITLE
Fix failing tests in pipeline

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
       - run: npm install
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
A local docker container with node:14 was able to run the tests, so maybe we have to bump the `node-version` from 10 to 14 for `actions/setup-node@v1` ?